### PR TITLE
Add Firestore persistence for payments

### DIFF
--- a/apis/firebase.ts
+++ b/apis/firebase.ts
@@ -25,3 +25,16 @@ export async function pushPayment(payment: any) {
   if (!db) return;
   await db.collection('payments').add(payment);
 }
+
+export async function fetchPayments() {
+  if (!db) return [];
+  const snapshot = await db.collection('payments').orderBy('timestamp', 'asc').get();
+  return snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as object) }));
+}
+
+export async function fetchCurrentGrid() {
+  if (!db) return null;
+  const doc = await db.collection('updates').doc('current').get();
+  if (!doc.exists) return null;
+  return doc.data() as { grid: string[][]; code: string; timestamp: any };
+}


### PR DESCRIPTION
## Summary
- save and fetch payments from Firebase instead of memory
- fetch the last grid from Firebase on startup
- expose helper methods to fetch payments and grid

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840794c6108832fa10fcd1f1bbeea5e