### PR TITLE
Implement firebase-backed updates

### DIFF
--- a/apis/payments.ts
+++ b/apis/payments.ts
@@ -12,7 +12,7 @@ export interface Payment {
 }
 
 // This function will now return a configured router, accepting only the broadcast function
-export default (broadcastPayment: (payment: Payment) => void) => {
+export default (broadcastAll: () => void) => {
   const paymentsRouter = Router();
 
   // GET route to retrieve all payments
@@ -51,7 +51,7 @@ export default (broadcastPayment: (payment: Payment) => void) => {
     try {
       await pushPayment(newPayment);
       try {
-        broadcastPayment(newPayment);
+        broadcastAll();
       } catch (broadcastErr) {
         console.error("Failed to broadcast payment", broadcastErr);
       }


### PR DESCRIPTION
## Summary
- load and store grid data with Firebase in `grid` API
- broadcast latest payments and grid over SSE every 2s
- fetch payments from database and broadcast list on update

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684080db5c60832f81baffb3c3cbe0cb